### PR TITLE
Remove panics

### DIFF
--- a/Packet.go
+++ b/Packet.go
@@ -70,7 +70,9 @@ func (packet *Packet) Write(writer io.Writer) error {
 // Bytes returns the raw byte slice serialization of the packet.
 func (packet *Packet) Bytes() []byte {
 	result := []byte{packet.Type}
+
 	result = append(result, Int64ToBytes(packet.Length)...)
 	result = append(result, packet.Data...)
+
 	return result
 }

--- a/Stream.go
+++ b/Stream.go
@@ -44,30 +44,35 @@ func (stream *Stream) Connection() net.Conn {
 // SetConnection sets the connection that the stream uses and
 // it can be called multiple times on a single stream,
 // effectively allowing you to hot-swap connections in failure cases.
-func (stream *Stream) SetConnection(connection net.Conn) {
+func (stream *Stream) SetConnection(connection net.Conn) error {
 	if connection == nil {
-		panic(errors.New("SetConnection using nil connection"))
+		return errors.New("SetConnection using nil connection")
 	}
 
 	stream.connection.Store(connection)
 
 	go stream.read(connection)
 	go stream.write(connection)
+
+	return nil
 }
 
 // OnError sets the callback that should be called when IO errors occur.
-func (stream *Stream) OnError(callback func(IOError)) {
+func (stream *Stream) OnError(callback func(IOError)) error {
 	if callback == nil {
-		panic(errors.New("OnError using nil callback"))
+		return errors.New("OnError using nil callback")
 	}
 
 	stream.onError = callback
+
+	return nil
 }
 
 // Close frees up the resources used by the stream and closes the connection.
-func (stream *Stream) Close() {
-	stream.Connection().Close()
+func (stream *Stream) Close() error {
 	close(stream.in)
+
+	return stream.Connection().Close()
 }
 
 // read starts a blocking routine that will read incoming messages.

--- a/Stream_test.go
+++ b/Stream_test.go
@@ -38,6 +38,10 @@ func startServer(t *testing.T, port int) net.Listener {
 		for {
 			conn, err := listener.Accept()
 
+			if conn == nil {
+				return
+			}
+
 			assert.NotNil(t, conn)
 			assert.Nil(t, err)
 
@@ -46,7 +50,6 @@ func startServer(t *testing.T, port int) net.Listener {
 			err = client.OnError(func(err packet.IOError) {
 				conn.Close()
 			})
-
 			assert.Nil(t, err)
 
 			err = client.SetConnection(conn)
@@ -152,6 +155,7 @@ func TestDisconnect(t *testing.T) {
 	client := packet.NewStream(1024)
 	err = client.SetConnection(conn)
 	assert.Nil(t, err)
+	defer client.Close()
 
 	// Send message
 	client.Outgoing <- packet.New(0, []byte("ping"))
@@ -195,8 +199,9 @@ func TestWriteTimeout(t *testing.T) {
 	defer conn.Close()
 
 	client := packet.NewStream(0)
-	client.SetConnection(conn)
+	err = client.SetConnection(conn)
 	assert.Nil(t, err)
+	defer client.Close()
 
 	// Send message
 	err = conn.SetWriteDeadline(time.Now())
@@ -240,6 +245,7 @@ func TestReadError(t *testing.T) {
 	client := packet.NewStream(0)
 	err = client.SetConnection(conn)
 	assert.Nil(t, err)
+	defer client.Close()
 
 	// Send message
 	client.Outgoing <- packet.New(0, []byte("ping"))


### PR DESCRIPTION
Panicking is not a good way to handle emergency situations. It's better to use errors instead. Especially in your case, when you need to check if connection or callback is not nil. Panicking is unnecessary here.